### PR TITLE
Add support for multiple values in `SQL.where`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ pg.query(SQL`UPDATE users ${SQL.set({ name: 'foo', age: 40 })} WHERE id = ${33}`
 
 ```js
 pg.query(SQL`INSERT INTO users ${SQL.values({ name: 'foo', age: 40 })}`)
+pg.query(SQL`INSERT INTO users ${SQL.values([{ name: 'foo', age: 40 }, { name: 'bar', age: 50 }])}`)
 ```
 
 ### spread

--- a/index.js
+++ b/index.js
@@ -179,6 +179,42 @@ class Values extends TreeNode {
   }
 }
 
+class ValuesArray extends TreeNode {
+  constructor(values) {
+    let tree = [];
+
+    if (values.length) {
+      let keys = Object.keys(values[0]);
+
+      if (keys.length) {
+        tree.push('(');
+
+        keys.forEach(key => {
+          tree.push(new Ident(key), ', ');
+        });
+
+        tree.pop();
+
+        tree.push(') VALUES (');
+
+        values.forEach(value => {
+          keys.forEach(key => {
+            tree.push(makeNode(value[key]), ', ');
+          });
+          tree.pop();
+          tree.push('), (');
+        });
+
+        tree.pop();
+
+        tree.push(')')
+      }
+    }
+
+    super(tree);
+  }
+}
+
 class Spread extends TreeNode {
   constructor(values) {
     let tree = [];
@@ -207,7 +243,6 @@ const mapping = {
   'expr': Expr,
   'where': Where,
   'set': SetValues,
-  'values': Values,
   'spread': Spread,
   'op': Op
 };
@@ -217,3 +252,8 @@ Object.keys(mapping).forEach(function(key) {
     return new mapping[key](...args);
   }
 })
+
+// Special case for SQL.values, since it's polymorphic.
+SQLTAG.values = function(values) {
+  return Array.isArray(values) ? new ValuesArray(values) : new Values(values)
+}

--- a/test/index.js
+++ b/test/index.js
@@ -75,11 +75,19 @@ describe('sqltag', function() {
     })
   })
 
-  it('should interpolate insert values', function() {
+  it('should interpolate insert values (object)', function() {
     expect(SQL`INSERT INTO table ${SQL.values({ name: 'foo', city: 'bar' })}`).to.deep.equal({
       sql: 'INSERT INTO table (`name`, `city`) VALUES (?, ?)',
       text: 'INSERT INTO table ("name", "city") VALUES ($1, $2)',
       values: ['foo', 'bar']
+    })
+  })
+
+  it('should interpolate insert values (array)', function() {
+    expect(SQL`INSERT INTO table ${SQL.values([{ name: 'foo', city: 'bar' }, { name: 'baz', city: 'quux' }])}`).to.deep.equal({
+      sql: 'INSERT INTO table (`name`, `city`) VALUES (?, ?), (?, ?)',
+      text: 'INSERT INTO table ("name", "city") VALUES ($1, $2), ($3, $4)',
+      values: ['foo', 'bar', 'baz', 'quux']
     })
   })
 


### PR DESCRIPTION
Useful for inserting multiple rows at once.