### PR TITLE
Add support for nested arrays in SQL.spread.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,5 @@ pg.query(SQL`INSERT INTO users ${SQL.values([{ name: 'foo', age: 40 }, { name: '
 
 ```js
 pg.query(SQL`SELECT * FROM users WHERE tags IN (${SQL.spread(['foo', 'bar', 'baz'])})`)
+pg.query(SQL`SELECT * FROM users WHERE tags IN (${SQL.spread([['foo', 'bar'], ['baz', 'quux']])})`)
 ```

--- a/index.js
+++ b/index.js
@@ -221,7 +221,16 @@ class Spread extends TreeNode {
 
     if (values.length) {
       values.forEach(value => {
-        tree.push(makeNode(value), ', ');
+        if (Array.isArray(value) && value.length) {
+          tree.push('(');
+          value.forEach(v => {
+            tree.push(makeNode(v), ', ');
+          });
+          tree.pop();
+          tree.push(')', ', ');
+        } else {
+          tree.push(makeNode(value), ', ');
+        }
       })
 
       tree.pop();

--- a/test/index.js
+++ b/test/index.js
@@ -99,6 +99,14 @@ describe('sqltag', function() {
     })
   })
 
+  it('should interpolate spread (nested)', function() {
+    expect(SQL`SELECT * from table WHERE (composite, key) IN (${SQL.spread([['foo', 'bar'], ['baz', 'quux']])})`).to.deep.equal({
+      sql: 'SELECT * from table WHERE (composite, key) IN ((?, ?), (?, ?))',
+      text: 'SELECT * from table WHERE (composite, key) IN (($1, $2), ($3, $4))',
+      values: ['foo', 'bar', 'baz', 'quux']
+    })
+  })
+
   it('should interpolate operators', function() {
     expect(SQL`SELECT * from table ${SQL.where({ age: SQL.op('>', 18) })}`).to.deep.equal({
       sql: 'SELECT * from table WHERE `age` > ?',


### PR DESCRIPTION
Recently I've been having a need for creating queries like.

```SQL
DELETE FROM some_table WHERE (composite, key) IN (('foo', 'bar'), ('baz', 'qux'), …, ('quux, 'quuz'))
```

or

```SQL
WITH updated (id, whatever) AS (VALUES (1, 'x'), (2, 'y'), … (100, 'xyz'))
  UPDATE some_table SET whatever = updated.whatever
  FROM updated
  WHERE some_table.id = updated.id
```

Extending `spread` to support nested arrays would allow me to make these kinds of queries easily. Or should it perhaps be a separate function?